### PR TITLE
Ensure that kubectl is present

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
@@ -125,7 +125,11 @@ namespace GoogleCloudExtension.GCloud
         /// <returns>A task that will be fulfilled to true if the method can be called, false otherwise.</returns>
         public static Task<bool> CanUseResetWindowsCredentialsAsync() => IsComponentInstalledAsync("beta");
 
-        public static Task<bool> CanUseKubectlAsync() => IsComponentInstalledAsync("kubectl");
+        /// <summary>
+        /// Returns true if the methods concerning kubectl and GKE can be used safely.
+        /// </summary>
+        /// <returns>A task that will be fullfilled to true if the GKE methods can be used.</returns>
+        public static Task<bool> CanUseGKEAsync() => IsComponentInstalledAsync("kubectl");
 
         /// <summary>
         /// Returns the list of components that gcloud knows about.

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
@@ -125,6 +125,8 @@ namespace GoogleCloudExtension.GCloud
         /// <returns>A task that will be fulfilled to true if the method can be called, false otherwise.</returns>
         public static Task<bool> CanUseResetWindowsCredentialsAsync() => IsComponentInstalledAsync("beta");
 
+        public static Task<bool> CanUseKubectlAsync() => IsComponentInstalledAsync("kubectl");
+
         /// <summary>
         /// Returns the list of components that gcloud knows about.
         /// </summary>

--- a/GoogleCloudExtension/GoogleCloudExtension.Utils/AsyncPropertyValue.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Utils/AsyncPropertyValue.cs
@@ -39,6 +39,8 @@ namespace GoogleCloudExtension.Utils
 
         public bool IsError => _valueSource?.IsFaulted ?? false;
 
+        public Task SourceCompleted => _valueSource;
+
         public AsyncPropertyValue(Task<T> valueSource, T defaultValue = default(T))
         {
             _valueSource = valueSource;

--- a/GoogleCloudExtension/GoogleCloudExtension.Utils/AsyncPropertyValue.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Utils/AsyncPropertyValue.cs
@@ -52,7 +52,7 @@ namespace GoogleCloudExtension.Utils
         /// Returns a task that will be completed once the wrapped task is completed. This task is
         /// not directly connected to the wrapped task and will never throw and error.
         /// </summary>
-        public Task SourceCompleted => _completionSource.Value.Task;
+        public Task ValueTask => _completionSource.Value.Task;
 
         public AsyncPropertyValue(Task<T> valueSource, T defaultValue = default(T))
         {

--- a/GoogleCloudExtension/GoogleCloudExtension.Utils/AsyncPropertyValue.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Utils/AsyncPropertyValue.cs
@@ -25,32 +25,45 @@ namespace GoogleCloudExtension.Utils
     public class AsyncPropertyValue<T> : Model
     {
         private readonly Task<T> _valueSource;
-        private T _value;
+        private readonly Lazy<TaskCompletionSource<bool>> _completionSource = new Lazy<TaskCompletionSource<bool>>();
 
         /// <summary>
         /// The value of the property, which will be set once Task where the value comes from
         /// is completed.
         /// </summary>
-        public T Value => _value;
+        public T Value { get; private set; }
 
+        /// <summary>
+        /// Returns whether the wrapped task is still pending.
+        /// </summary>
         public bool IsPending => !_valueSource?.IsCompleted ?? false;
 
+        /// <summary>
+        /// Returns true if the wrapped task is completed.
+        /// </summary>
         public bool IsCompleted => _valueSource?.IsCompleted ?? true;
 
+        /// <summary>
+        /// Returns true if the wrapped task is in error.
+        /// </summary>
         public bool IsError => _valueSource?.IsFaulted ?? false;
 
-        public Task SourceCompleted => _valueSource;
+        /// <summary>
+        /// Returns a task that will be completed once the wrapped task is completed. This task is
+        /// not directly connected to the wrapped task and will never throw and error.
+        /// </summary>
+        public Task SourceCompleted => _completionSource.Value.Task;
 
         public AsyncPropertyValue(Task<T> valueSource, T defaultValue = default(T))
         {
             _valueSource = valueSource;
-            _value = defaultValue;
+            Value = defaultValue;
             AwaitForValue();
         }
 
         public AsyncPropertyValue(T value)
         {
-            _value = value;
+            Value = value;
         }
 
         private void AwaitForValue()
@@ -59,8 +72,9 @@ namespace GoogleCloudExtension.Utils
             {
                 if (t.IsCompleted)
                 {
-                    _value = t.Result;
+                    Value = t.Result;
                 }
+                _completionSource.Value.SetResult(true);
                 RaiseAllPropertyChanged();
             });
         }

--- a/GoogleCloudExtension/GoogleCloudExtension/Analytics/Events/UnhandledExceptionEvent.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Analytics/Events/UnhandledExceptionEvent.cs
@@ -24,18 +24,20 @@ namespace GoogleCloudExtension.Analytics.Events
         private const string UnhandledExceptionEventName = "unhandledException";
         private const string ExceptionProperty = "exception";
 
-        public static AnalyticsEvent Create(AggregateException ex)
-        {
-            return new AnalyticsEvent(
-                UnhandledExceptionEventName,
-                ExceptionProperty, ex.InnerException.GetType().Name);
-        }
-
         public static AnalyticsEvent Create(Exception ex)
         {
-            return new AnalyticsEvent(
-                UnhandledExceptionEventName,
-                ExceptionProperty, ex.GetType().Name);
+            if (ex is AggregateException)
+            {
+                return new AnalyticsEvent(
+                    UnhandledExceptionEventName,
+                    ExceptionProperty, ex.InnerException.GetType().Name);
+            }
+            else
+            {
+                return new AnalyticsEvent(
+                    UnhandledExceptionEventName,
+                    ExceptionProperty, ex.GetType().Name);
+            }
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/ManageWindowsCredentials/ManageWindowsCredentialsViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ManageWindowsCredentials/ManageWindowsCredentialsViewModel.cs
@@ -237,7 +237,7 @@ namespace GoogleCloudExtension.ManageWindowsCredentials
                 {
                     UserPromptUtils.ErrorPrompt(
                         message: Resources.ResetPasswordGcloudMissingBetaMessage,
-                        title: Resources.ResetPasswordGcloudMissingComponentTitle);
+                        title: Resources.GcloudMissingComponentTitle);
                 }
                 return false;
             }

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/IPublishDialog.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/IPublishDialog.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using GoogleCloudExtension.SolutionUtils;
+using System.Threading.Tasks;
 
 namespace GoogleCloudExtension.PublishDialog
 {
@@ -41,5 +42,11 @@ namespace GoogleCloudExtension.PublishDialog
         /// Called from a step that wants to finish the flow. In essence closes the dialog.
         /// </summary>
         void FinishFlow();
+
+        /// <summary>
+        /// Set the busy state following the given task.
+        /// </summary>
+        /// <param name="task">The task to follow, the dialog will be busy until the task is completed.</param>
+        void FollowTask(Task task);
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/IPublishDialog.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/IPublishDialog.cs
@@ -44,9 +44,9 @@ namespace GoogleCloudExtension.PublishDialog
         void FinishFlow();
 
         /// <summary>
-        /// Set the busy state following the given task.
+        /// Makes the dialog look "busy" as long as <paramref name="task"/> is not completed.
         /// </summary>
-        /// <param name="task">The task to follow, the dialog will be busy until the task is completed.</param>
-        void FollowTask(Task task);
+        /// <param name="task">The task.</param>
+        void TrackTask(Task task);
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogWindowContent.xaml
@@ -21,7 +21,7 @@
         <Binding Source="{StaticResource CommonDialogStyleDynamicLarge}" />
     </UserControl.Style>
 
-    <theming:CommonDialogWindowBaseContent Content="{Binding Content}" HasBanner="True">
+    <theming:CommonDialogWindowBaseContent Content="{Binding Content}" HasBanner="True" IsEnabled="{Binding IsReady}" >
         <theming:CommonDialogWindowBaseContent.Buttons>
             <theming:DialogButtonInfo Caption="{x:Static ext:Resources.PublishDialogPrevButtonCaption}"
                                       Command="{Binding PrevCommand}"/>

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogWindowViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogWindowViewModel.cs
@@ -57,6 +57,9 @@ namespace GoogleCloudExtension.PublishDialog
         /// </summary>
         public ProtectedCommand PublishCommand { get; }
 
+        /// <summary>
+        /// Whether the dialog is ready to process user input (enabled) or not.
+        /// </summary>
         public bool IsReady
         {
             get { return _isReady; }

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogWindowViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogWindowViewModel.cs
@@ -16,6 +16,7 @@ using GoogleCloudExtension.SolutionUtils;
 using GoogleCloudExtension.Utils;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using System.Windows;
 
 namespace GoogleCloudExtension.PublishDialog
@@ -30,6 +31,7 @@ namespace GoogleCloudExtension.PublishDialog
         private readonly ISolutionProject _project;
         private readonly Stack<IPublishDialogStep> _stack = new Stack<IPublishDialogStep>();
         private FrameworkElement _content;
+        private bool _isReady = true;
 
         /// <summary>
         /// The content to display to the user, the content of the active <seealso cref="IPublishDialogStep"/> .
@@ -54,6 +56,12 @@ namespace GoogleCloudExtension.PublishDialog
         /// The command to execute when presing the "Publish" button.
         /// </summary>
         public ProtectedCommand PublishCommand { get; }
+
+        public bool IsReady
+        {
+            get { return _isReady; }
+            set { SetValueAndRaise(ref _isReady, value); }
+        }
 
         /// <summary>
         /// The current <seealso cref="IPublishDialogStep"/> being shown.
@@ -143,6 +151,13 @@ namespace GoogleCloudExtension.PublishDialog
         }
 
         #region IPublishDialog
+
+        async void IPublishDialog.FollowTask(Task task)
+        {
+            IsReady = false;
+            await task;
+            IsReady = true;
+        }
 
         ISolutionProject IPublishDialog.Project => _project;
 

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogWindowViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogWindowViewModel.cs
@@ -152,11 +152,27 @@ namespace GoogleCloudExtension.PublishDialog
 
         #region IPublishDialog
 
-        async void IPublishDialog.FollowTask(Task task)
+        async void IPublishDialog.TrackTask(Task task)
         {
-            IsReady = false;
-            await task;
-            IsReady = true;
+            try
+            {
+                IsReady = false;
+                await task;
+            }
+            catch (Exception ex)
+            {
+                // This method is not interested at all in the exceptions thrown from the task. Other parts of the
+                // extension will handle that error. But if we detect that there's a critical error we will let it
+                // propagate.
+                if (ErrorHandlerUtils.IsCriticalException(ex))
+                {
+                    throw;
+                }
+            }
+            finally
+            {
+                IsReady = true;
+            }
         }
 
         ISolutionProject IPublishDialog.Project => _project;

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepContent.xaml
@@ -16,7 +16,7 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <StackPanel IsEnabled="{Binding Clusters.IsCompleted}">
+    <StackPanel>
         <Label Content="{x:Static ext:Resources.GkePublishClusterMessage}"
                Target="{Binding ElementName=_clusters}"
                Style="{StaticResource CommonLabelStyle}"/>

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
@@ -245,7 +245,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
 
         private async Task<bool> VerifyGCloudDependencies()
         {
-            if (!await GCloudWrapper.CanUseKubectlAsync())
+            if (!await GCloudWrapper.CanUseGKEAsync())
             {
                 if (!GCloudWrapper.IsGCloudCliInstalled())
                 {

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
@@ -117,7 +117,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
             DeploymentVersion = GetDefaultVersion();
 
             // Mark that the dialog is going to be busy until we have loaded the data.
-            _publishDialog.TrackTask(Clusters.SourceCompleted);
+            _publishDialog.TrackTask(Clusters.ValueTask);
         }
 
         /// <summary>
@@ -257,7 +257,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
                 {
                     UserPromptUtils.ErrorPrompt(
                         message: Resources.GkePublishMissingKubectlMessage,
-                        title: Resources.ResetPasswordGcloudMissingComponentTitle);
+                        title: Resources.GcloudMissingComponentTitle);
                 }
                 return false;
             }

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -1996,7 +1996,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To use this feature you need to have the &quot;lubectl&quot; component of the Google Cloud SDK installed. Please do so by running the command: gcloud components install kubectl.
+        ///   Looks up a localized string similar to To use this feature you need to have the &quot;kubectl&quot; component of the Google Cloud SDK installed. Please do so by running the command: gcloud components install kubectl.
         /// </summary>
         public static string GkePublishMissingKubectlMessage {
             get {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -1987,6 +1987,15 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to To use this feature you need to have the &quot;lubectl&quot; component of the Google Cloud SDK installed. Please do so by running the command: gcloud components install kubectl.
+        /// </summary>
+        public static string GkePublishMissingKubectlMessage {
+            get {
+                return ResourceManager.GetString("GkePublishMissingKubectlMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Service {0} ip address {1}.
         /// </summary>
         public static string GkePublishServiceIpMessage {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -1915,6 +1915,15 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Missing Google Cloud SDK Component.
+        /// </summary>
+        public static string GcloudMissingComponentTitle {
+            get {
+                return ResourceManager.GetString("GcloudMissingComponentTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Clusters:.
         /// </summary>
         public static string GkePublishClusterMessage {
@@ -2523,15 +2532,6 @@ namespace GoogleCloudExtension {
         public static string ResetPasswordGcloudMissingBetaMessage {
             get {
                 return ResourceManager.GetString("ResetPasswordGcloudMissingBetaMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Missing Google Cloud SDK Component.
-        /// </summary>
-        public static string ResetPasswordGcloudMissingComponentTitle {
-            get {
-                return ResourceManager.GetString("ResetPasswordGcloudMissingComponentTitle", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -1347,6 +1347,10 @@
     <value>E_xpose the service to the public internet</value>
     <comment>Caption for the checkbox to set if the GKE service is to be exposed or not.</comment>
   </data>
+  <data name="GkePublishMissingKubectlMessage" xml:space="preserve">
+    <value>To use this feature you need to have the "lubectl" component of the Google Cloud SDK installed. Please do so by running the command: gcloud components install kubectl</value>
+    <comment>Message shown to the user when the kubectl component is not installed.</comment>
+  </data>
   <data name="GkePublishServiceIpMessage" xml:space="preserve">
     <value>Service {0} ip address {1}</value>
     <comment>Message printed in the output window to show the IP address of the service exposed. {0} is the deployment name, {1} is the IP address.</comment>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -1348,7 +1348,7 @@
     <comment>Caption for the checkbox to set if the GKE service is to be exposed or not.</comment>
   </data>
   <data name="GkePublishMissingKubectlMessage" xml:space="preserve">
-    <value>To use this feature you need to have the "lubectl" component of the Google Cloud SDK installed. Please do so by running the command: gcloud components install kubectl</value>
+    <value>To use this feature you need to have the "kubectl" component of the Google Cloud SDK installed. Please do so by running the command: gcloud components install kubectl</value>
     <comment>Message shown to the user when the kubectl component is not installed.</comment>
   </data>
   <data name="GkePublishServiceIpMessage" xml:space="preserve">

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -633,7 +633,7 @@
     <value>To use this feature you need to have the "beta" component of the Google Cloud SDK installed. Please do so by running the command: gcloud components install beta.</value>
     <comment>Message shown when the beta component is missing.</comment>
   </data>
-  <data name="ResetPasswordGcloudMissingComponentTitle" xml:space="preserve">
+  <data name="GcloudMissingComponentTitle" xml:space="preserve">
     <value>Missing Google Cloud SDK Component</value>
     <comment>Title for the dialog that informs the user that a Cloud SDK component is needed but not installed.</comment>
   </data>

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/UserPromptUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/UserPromptUtils.cs
@@ -100,20 +100,18 @@ namespace GoogleCloudExtension.Utils
         /// <param name="ex">The exception to show.</param>
         public static void ExceptionPrompt(Exception ex)
         {
-            ErrorPrompt(
-                Resources.ExceptionPromptTitle,
-                String.Format(Resources.ExceptionPromptMessage, ex.Message));
-        }
-
-        /// <summary>
-        /// Shows an error message for the given <seealso cref="AggregateException"/>.
-        /// </summary>
-        /// <param name="ex">The exception to show.</param>
-        public static void ExceptionPrompt(AggregateException ex)
-        {
-            ErrorPrompt(
-                Resources.ExceptionPromptTitle,
-                String.Format(Resources.ExceptionPromptMessage, ex.InnerException.Message));
+            if (ex is AggregateException)
+            {
+                ErrorPrompt(
+                    Resources.ExceptionPromptTitle,
+                    String.Format(Resources.ExceptionPromptMessage, ex.InnerException.Message));
+            }
+            else
+            {
+                ErrorPrompt(
+                    Resources.ExceptionPromptTitle,
+                    String.Format(Resources.ExceptionPromptMessage, ex.Message));
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds functionality to ensure that kubectl is present in the system before attempting to deploy the app to GKE. There are also some refactoring to change the way the exceptions and errors are handled to allow the deployment code to handle exceptions as well. This new model will be ported to other publish dialog steps in further PRs.

Also added a small mechanism so a publish dialog step can control whether the dialog UI is enabled/disabled when running tasks. This allows for the UI to be disabled while it is not ready to process user input in a safe and consistent way.